### PR TITLE
Point to Buildroot External in the org level README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -65,8 +65,8 @@ organization:
 - [PolarFire SoC Yocto BSP](https://github.com/polarfire-soc/meta-polarfire-soc-yocto-bsp):
   Yocto based Linux build system for PolarFire SoC
 
-- [PolarFire SoC Buildroot SDK](https://github.com/polarfire-soc/polarfire-soc-buildroot-sdk):
-  Buildroot based Linux build system for PolarFire SoC
+- [Microchip Buildroot External](https://github.com/linux4microchip/buildroot-external-microchip):
+  Buildroot based Linux build system for PolarFire SoC & other Microchip SoCs.
 
 **Real Time Operating Systems (RTOS)**
 


### PR DESCRIPTION
The Buildroot SDK has been deprecated and archived with the release of PolarFire SoC support in Linux4Microchip's common "Microchip Buildroot External". Update the org level README to link to its location.

Signed-off-by: Conor Dooley <conor.dooley@microchip.com>